### PR TITLE
Fix to check if device_path set to empty string

### DIFF
--- a/trove/instance/models.py
+++ b/trove/instance/models.py
@@ -731,7 +731,7 @@ class Instance(BuiltInstance):
                 raise exception.LocalStorageNotSupported()
             if new_flavor_size == old_flavor_size:
                 raise exception.CannotResizeToSameSize()
-        elif CONF.device_path is not None:
+        elif CONF.device_path is not None or not '':
             # ephemeral support enabled
             if new_flavor.ephemeral == 0:
                 raise exception.LocalStorageNotSpecified(flavor=new_flavor_id)


### PR DESCRIPTION
- Trove config does not allow the config option 'device_path' to be set to None.
  It has a default String value and setting an empty value in trove.conf will set the config option to empty string.
- This causes trove resize_flavor in models.py to throw an exception. 
- Fix mad to also check for empty string in device_path
