### PR TITLE
Fix to check if device_path set to empty string

### DIFF
--- a/trove/instance/models.py
+++ b/trove/instance/models.py
@@ -741,7 +741,7 @@ class Instance(BuiltInstance):
                 raise exception.LocalStorageNotSupported()
             if new_flavor_size == old_flavor_size:
                 raise exception.CannotResizeToSameSize()
-        elif self.device_path is not None:
+        elif self.device_path is not None or self.device_path != '':
             # ephemeral support enabled
             if new_flavor.ephemeral == 0:
                 raise exception.LocalStorageNotSpecified(flavor=new_flavor_id)


### PR DESCRIPTION
- Trove config does not allow the config option 'device_path' to be set to None.
- It has a default String value and setting an empty value in trove.conf will set the config option to empty string.
- This causes trove resize_flavor ( trove/trove/instance/models.py ) to throw an exception.
- Fix made to get device path to check for empty string as well
