### PR TITLE
flavor_id may be alphanumeric for tenant created flavors

### DIFF
--- a/trove/flavor/views.py
+++ b/trove/flavor/views.py
@@ -29,7 +29,7 @@ class FlavorView(object):
     def data(self):
 
         flavor = {
-            'id': int(self.flavor.id),
+            'id': self.flavor.id,
             'links': self._build_links(),
             'name': self.flavor.name,
             'ram': self.flavor.ram,


### PR DESCRIPTION
I have created many tenant-owned flavors (icehouse) and trove flavor-list spits an error when trying to convert the ids to int. 
