### PR TITLE
Fix unassign_configuration bug. In api layout, db trove.instances.con…

### DIFF
--- a/trove/instance/service.py
+++ b/trove/instance/service.py
@@ -273,8 +273,6 @@ class InstanceController(wsgi.Controller):
                 instance.assign_configuration(kwargs['configuration_id'])
             else:
                 instance.unassign_configuration()
-        if kwargs:
-            instance.update_db(**kwargs)
 
     def update(self, req, id, body, tenant_id):
         """Updates the instance to attach/detach configuration."""

--- a/trove/taskmanager/models.py
+++ b/trove/taskmanager/models.py
@@ -1191,17 +1191,8 @@ class BuiltInstanceTasks(BuiltInstance, NotifyMixin, ConfigurationMixin):
                    "%s.") % self.id)
         LOG.debug("overrides: %s" % overrides)
         LOG.debug("self.ds_version: %s" % self.ds_version.__dict__)
-        LOG.debug("self.configuration.id: %s" % self.configuration.id)
-        # check if the configuration requires a restart of the instance
-        config = Configuration(self.context, self.configuration.id)
-        need_restart = config.does_configuration_need_restart()
-        LOG.debug("do we need a restart?: %s" % need_restart)
-        if need_restart:
-            status = inst_models.InstanceTasks.RESTART_REQUIRED
-            self.update_db(task_status=status)
 
         flavor = self.nova_client.flavors.get(self.flavor_id)
-
         config_overrides = self._render_override_config(
             flavor,
             overrides=overrides)


### PR DESCRIPTION
…figuration_id had been set None, but after api layout rpc cast taskmanager, taskmanager/models.BuiltInstanceTasks.update_overrides uses the db trove.instances.configuration_id again, it cause an exception